### PR TITLE
MAX-7710 Map Icon seems too thick

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+v2.2.0
+* add strokeWidth in nav item
+
 v2.1.7
 ==================
 * Fix demo for IE

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-app-nav",
   "author": "General Electric",
   "description": "A navigation component that allows the user to browse app pages and content",
-  "version": "2.1.7",
+  "version": "2.2.0",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-app-nav-item.es6.js
+++ b/px-app-nav-item.es6.js
@@ -32,6 +32,14 @@
       },
 
       /**
+       * Used to set the icon's stroke-width
+       */
+      strokeWidth: {
+        type: Number,
+        value: 1,
+      },
+
+      /**
        * Set to `true` if this is a subitem.
        */
       subitem: {

--- a/px-app-nav-item.html
+++ b/px-app-nav-item.html
@@ -25,7 +25,7 @@ limitations under the License.
     <style include="px-app-nav-item-styles"></style>
 
     <template is="dom-if" if="{{_propIsTypeOf(icon, 'string')}}">
-      <px-icon class$="app-nav-item__icon {{_addClassIfHasLabel(label)}}" icon="{{icon}}"></px-icon>
+      <px-icon class$="app-nav-item__icon {{_addClassIfHasLabel(label)}}" style="stroke-width: {{strokeWidth}}" icon="{{icon}}"></px-icon>
     </template>
 
     <template is="dom-if" if="{{emptyIcon}}">

--- a/px-app-nav.html
+++ b/px-app-nav.html
@@ -467,7 +467,7 @@ Custom property | Description
 
             <!-- Stamp plain old items, which hold children -->
             <template is="dom-if" if="[[_isItemNotParent(item, keys.children)}}">
-              <px-app-nav-item item="[[item]]" label="[[_getItemProp(item, keys.label)]]" icon="[[_getItemProp(item, keys.icon)]]" selected$="[[_isItemSelected(item, selectedMeta.item)]]"></px-app-nav-item>
+              <px-app-nav-item item="[[item]]" label="[[_getItemProp(item, keys.label)]]" stroke-width="[[_getItemProp(item, 'strokeWidth')]]" icon="[[_getItemProp(item, keys.icon)]]" selected$="[[_isItemSelected(item, selectedMeta.item)]]"></px-app-nav-item>
             </template>
           </template>
         </template>
@@ -500,7 +500,7 @@ Custom property | Description
 
               <!-- Stamp plain old items, which hold children -->
               <template is="dom-if" if="[[_isItemNotParent(item, keys.children)]]">
-                <px-app-nav-item item="[[item]]" label="[[_getItemProp(item, keys.label)]]" icon="[[_getItemProp(item, keys.icon)]]" selected$="[[_isItemSelected(item, selectedMeta.item)]]" overflowed$="[[someOverflowed]]" collapsed$="[[allCollapsed]]">
+                <px-app-nav-item item="[[item]]" label="[[_getItemProp(item, keys.label)]]" stroke-width="[[_getItemProp(item, 'strokeWidth')]]" icon="[[_getItemProp(item, keys.icon)]]" selected$="[[_isItemSelected(item, selectedMeta.item)]]" overflowed$="[[someOverflowed]]" collapsed$="[[allCollapsed]]">
                 </px-app-nav-item>
               </template>
             </template>
@@ -522,7 +522,7 @@ Custom property | Description
 
             <!-- Stamp plain old items, which hold children -->
             <template is="dom-if" if="[[_isItemNotParent(item, keys.children)]]">
-              <px-app-nav-item item="[[item]]" label="[[_getItemProp(item, keys.label)]]" icon="[[_getItemProp(item, keys.icon)]]" selected$="[[_isItemSelected(item, selectedMeta.item)]]" collapsed only-show-icon$="[[!verticalOpened]]" empty-icon="[[_isIconEmpty(item, keys.icon)]]">
+              <px-app-nav-item item="[[item]]" label="[[_getItemProp(item, keys.label)]]" stroke-width="[[_getItemProp(item, 'strokeWidth')]]" icon="[[_getItemProp(item, keys.icon)]]" selected$="[[_isItemSelected(item, selectedMeta.item)]]" collapsed only-show-icon$="[[!verticalOpened]]" empty-icon="[[_isIconEmpty(item, keys.icon)]]">
               </px-app-nav-item>
             </template>
           </template>


### PR DESCRIPTION
Add `strokeWidth` property for the items, then we could config the nav item icon's `stroke-width`.

@joshsylvester @elvinfucom @shinxi , please help review.